### PR TITLE
Add support for authentication

### DIFF
--- a/examples/react-github/gqless.config.ts
+++ b/examples/react-github/gqless.config.ts
@@ -1,0 +1,8 @@
+import { Config } from '@gqless/cli'
+
+const config: Config = {
+  url: `https://api.github.com/graphql?access_token=${process.env.GITHUB_AUTH}`,
+  outputDir: './src/graphql',
+}
+
+export default config

--- a/examples/react-github/package.json
+++ b/examples/react-github/package.json
@@ -19,7 +19,7 @@
     "@gqless/cli": "^0.0.1-alpha.23"
   },
   "scripts": {
-    "generate": "../../packages/cli/bin/run-dev generate -u https://api.github.com/graphql?access_token=$GITHUB_AUTH src/graphql -t",
+    "generate": "../../packages/cli/bin/run-dev generate",
     "start": "parcel index.html --open"
   }
 }

--- a/examples/react-github/src/graphql/generated/schema.ts
+++ b/examples/react-github/src/graphql/generated/schema.ts
@@ -1449,6 +1449,9 @@ export const schema = {
             true
           )
         },
+        get sponsorsListing() {
+          return new FieldNode(schema.SponsorsListing, undefined, true)
+        },
         get sponsorshipsAsMaintainer() {
           return new FieldNode(
             schema.SponsorshipConnection,
@@ -5121,6 +5124,9 @@ export const schema = {
   get Sponsorable() {
     return new InterfaceNode(
       {
+        get sponsorsListing() {
+          return new FieldNode(schema.SponsorsListing, undefined, true)
+        },
         get sponsorshipsAsMaintainer() {
           return new FieldNode(
             schema.SponsorshipConnection,
@@ -5758,6 +5764,9 @@ export const schema = {
             undefined,
             true
           )
+        },
+        get sponsorsListing() {
+          return new FieldNode(schema.SponsorsListing, undefined, true)
         },
         get sponsorshipsAsMaintainer() {
           return new FieldNode(

--- a/examples/react-github/src/graphql/generated/types.ts
+++ b/examples/react-github/src/graphql/generated/types.ts
@@ -617,6 +617,7 @@ type t_Query = FieldsType<
     >
 
     /**
+     * @deprecated `Query.sponsorsListing` will be removed. Use `Sponsorable.sponsorsListing` instead. Removal on 2020-04-01 UTC.
      * Look up a single Sponsors Listing
      */
     sponsorsListing: FieldsTypeArg<{ slug: string }, t_SponsorsListing | null>
@@ -1310,6 +1311,11 @@ type t_User = FieldsType<
       },
       t_SavedReplyConnection | null
     >
+
+    /**
+     * The GitHub Sponsors listing for this user.
+     */
+    sponsorsListing: t_SponsorsListing | null
 
     /**
      * This object's sponsorships as the maintainer.
@@ -5072,6 +5078,11 @@ type t_Organization = FieldsType<
      * The Organization's SAML identity providers
      */
     samlIdentityProvider: t_OrganizationIdentityProvider | null
+
+    /**
+     * The GitHub Sponsors listing for this user.
+     */
+    sponsorsListing: t_SponsorsListing | null
 
     /**
      * This object's sponsorships as the maintainer.

--- a/examples/react-hackernews/.gqlessrc.json
+++ b/examples/react-hackernews/.gqlessrc.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://www.graphqlhub.com/graphql",
+  "outputDir": "./src/graphql"
+}

--- a/examples/react-hackernews/package.json
+++ b/examples/react-hackernews/package.json
@@ -19,7 +19,7 @@
     "@gqless/cli": "^0.0.1-alpha.23"
   },
   "scripts": {
-    "generate": "../../packages/cli/bin/run-dev generate -u https://www.graphqlhub.com/graphql src/graphql -t",
+    "generate": "../../packages/cli/bin/run-dev generate",
     "start": "parcel index.html --open"
   }
 }

--- a/gqless/example/.gqlessrc.json
+++ b/gqless/example/.gqlessrc.json
@@ -1,0 +1,4 @@
+{
+  "url": "http://127.0.0.1:9002/graphql",
+  "outputDir": "./graphql"
+}

--- a/gqless/example/package.json
+++ b/gqless/example/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "start": "graphql-faker & parcel index.html",
-    "generate": "../../packages/cli/bin/run-dev generate -t -u http://127.0.0.1:9002/graphql ./graphql",
+    "generate": "../../packages/cli/bin/run-dev generate",
     "build": "parcel build index.html"
   },
   "dependencies": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,26 +31,35 @@ USAGE
 # Commands
 
 <!-- commands -->
-* [`gqless generate OUTPUT_DIR`](#gqless-generate-output_dir)
+* [`gqless generate [OUTPUT_DIR]`](#gqless-generate-output_dir)
 * [`gqless help [COMMAND]`](#gqless-help-command)
 
-## `gqless generate OUTPUT_DIR`
+## `gqless generate [OUTPUT_DIR]`
 
-generate a client from a GraphQL endpoint
+Generate a client from a GraphQL endpoint
 
 ```
 USAGE
-  $ gqless generate OUTPUT_DIR
+  $ gqless generate [OUTPUT_DIR]
 
 OPTIONS
-  -h, --help        show CLI help
-  -t, --typescript  output typescript (instead of javascript)
-  -u, --url=url     (required) url to the GraphQL endpoint
-  --noComments      don't output comments (only useful for IDE intellisense)
-  --noPrettier      don't run prettier on the resulting code
+  -c, --config=config  Path to your gqless config file
+  -h, --help           show CLI help
+  -t, --typescript     output typescript (instead of javascript)
+  -u, --url=url        url to the GraphQL endpoint
 
-EXAMPLE
-  $ gqless generate https://example.com/graphql
+  --header=header      Additional header to send to server for introspectionQuery. May be used multiple times to add
+                       multiple headers.
+
+  --noComments         don't output comments (only useful for IDE intellisense)
+
+  --noPrettier         don't run prettier on the resulting code
+
+  --usePost            use a POST request to retrieve the schema
+
+EXAMPLES
+  $ gqless generate ./src/gqless -u https://example.com/graphql
+  $ gqless generate -c ./src/gqless.config.ts
 ```
 
 _See code: [dist/commands/generate.js](https://github.com/samdenty/gqless/blob/v0.0.1-alpha.23/dist/commands/generate.js)_

--- a/packages/cli/bin/run-dev
+++ b/packages/cli/bin/run-dev
@@ -1,4 +1,20 @@
 #!/usr/bin/env node
 
+const path = require('path')
+process.env.TS_NODE_PROJECT = path.resolve(
+  path.dirname(module.filename),
+  '../tsconfig.json'
+)
+
 require('tsconfig-paths/register')
-require('./run')
+
+require('@oclif/config')
+  .load(module.filename)
+  .then(config => {
+    config.pjson.oclif.commands = './src/commands'
+
+    require('@oclif/command')
+      .run(undefined, config)
+      .then(require('@oclif/command/flush'))
+      .catch(require('@oclif/errors/handle'))
+  })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,10 +14,12 @@
     "directory": "packages/cli"
   },
   "dependencies": {
+    "@endemolshinegroup/cosmiconfig-typescript-loader": "^1.0.1",
     "@gqless/schema": "^0.0.1-alpha.23",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1",
     "@oclif/plugin-help": "^2",
+    "cosmiconfig": "^5.2.1",
     "got": "^9.6.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1",
@@ -28,6 +30,7 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
+    "@types/cosmiconfig": "^5.0.3",
     "@types/got": "^9.4.4",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^12.11.7",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@oclif/dev-cli": "^1",
-    "@types/cosmiconfig": "^5.0.3",
     "@types/got": "^9.4.4",
     "@types/mkdirp": "^0.5.2",
     "@types/node": "^12.11.7",
@@ -56,7 +55,6 @@
     ]
   },
   "scripts": {
-    "dev": "./bin/run-dev",
     "build": "rm -rf dist; tsc -p tsconfig.build.json && oclif-dev readme"
   },
   "types": "dist/index.d.ts",

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,19 +1,55 @@
 import { Command, flags } from '@oclif/command'
-import { get } from 'got'
+import { get, post } from 'got'
 import { QueryFetcher } from 'gqless'
 import * as path from 'path'
-import { generateSchema } from '../generateSchema'
+import { generateSchema } from '../utils/generateSchema'
+import { getConfig, Config } from '../utils/config';
+
+export interface Flags {
+  config?: string;
+  header?: string[];
+  url?: string;
+  usePost: boolean;
+  noComments: boolean;
+  noPrettier: boolean;
+  typescript: boolean;
+}
+
+const headersArrayToObject = (
+  arr?: string[]
+): Record<string, string> | undefined => {
+  if (!arr) return;
+  return arr
+    .map(val => JSON.parse(val))
+    .reduce((pre, next) => ({ ...pre, ...next }), {});
+};
 
 export default class Generate extends Command {
-  static description = 'generate a client from a GraphQL endpoint'
+  static description = 'Generate a client from a GraphQL endpoint'
 
   static examples = [
-    `$ gqless generate https://example.com/graphql
-`,
+    `$ gqless generate ./src/gqless -u https://example.com/graphql`,
+    `$ gqless generate -c ./src/gqless.config.ts`,
   ]
 
   static flags = {
     help: flags.help({ char: 'h' }),
+
+    config: flags.string({
+      char: 'c',
+      description: 'Path to your gqless config file'
+    }),
+
+    header: flags.string({
+      multiple: true,
+      parse: header => {
+        const separatorIndex = header.indexOf(':');
+        const key = header.substring(0, separatorIndex).trim();
+        const value = header.substring(separatorIndex + 1).trim();
+        return JSON.stringify({ [key]: value });
+      },
+      description: 'Additional header to send to server for introspectionQuery. May be used multiple times to add multiple headers.'
+    }),
 
     noComments: flags.boolean({
       description: `don't output comments (only useful for IDE intellisense)`,
@@ -25,24 +61,39 @@ export default class Generate extends Command {
     url: flags.string({
       char: 'u',
       description: 'url to the GraphQL endpoint',
-      required: true,
     }),
 
     typescript: flags.boolean({
       char: 't',
       description: 'output typescript (instead of javascript)',
     }),
+
+    usePost: flags.boolean({
+      description: 'use a POST request to retrieve the schema'
+    })
+
   }
 
-  static args = [{ name: 'output_dir', required: true }]
+  static args = [{ name: 'output_dir' }]
 
   async run() {
-    const { args, flags } = this.parse(Generate)
+    const { args, flags } = this.parse(Generate as any)
+
+    const config = await this.createConfig(args, flags);
+
+    if (!config.url) {
+      this.error('The url to the graphql endpoints is missing. You can use the -u flag or provide it in the config file.');
+    }
+
+    if (!config.outputDir) {
+      this.error('The output directory is missing. You can pass it to the command or include it in the config file.');
+    }
 
     const fetchQuery: QueryFetcher = async (query, variables) => {
-      const response = await get(flags.url, {
+      const response = await (config.usePost ? post : get)(config.url as string, {
         headers: {
           'Content-Type': 'application/json',
+          ...(config.headers || {})
         },
         body: JSON.stringify({
           query,
@@ -52,9 +103,38 @@ export default class Generate extends Command {
       return JSON.parse(response.body)
     }
 
-    await generateSchema(fetchQuery, {
-      ...flags,
-      outputDir: path.join(process.cwd(), args.output_dir),
-    })
+    await generateSchema(fetchQuery, config as Config & {outputDir: string});
+  }
+
+  async createConfig(args: {output_dir?: string}, flags: Flags): Promise<Config> {
+    let config: Config | null = null;
+    try {
+      config = await getConfig({
+        configFileName: flags.config
+      });
+    } catch (error) {
+      this.error(error.message);
+    }
+
+    const {header, ...rest} = flags;
+
+    config = {
+      ...(config || {}),
+      ...rest
+    };
+
+    if (header) {
+      config.headers = headersArrayToObject(header);
+    }
+
+    if (args.output_dir) {
+      config.outputDir = args.output_dir;
+    }
+
+    if (config.outputDir) {
+      config.outputDir = path.join(process.cwd(), config.outputDir);
+    }
+
+    return config;
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,2 @@
 export { run } from '@oclif/command'
-export * from './generateSchema'
+export * from './utils/generateSchema'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,2 +1,3 @@
 export { run } from '@oclif/command'
-export * from './utils/generateSchema'
+
+export * from './utils'

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,0 +1,51 @@
+import cosmiconfig, { LoaderEntry } from "cosmiconfig";
+import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
+import { resolve, parse } from "path";
+
+export interface Config {
+  config?: string;
+  headers?: Record<string, string>;
+  url?: string;
+  outputDir?: string;
+  usePost: boolean;
+  noComments: boolean;
+  noPrettier: boolean;
+  typescript: boolean;
+}
+
+const MODULE_NAME = "gqless";
+const defaultFileNames = [
+  "package.json",
+  `${MODULE_NAME}.config.js`,
+  `${MODULE_NAME}.config.ts`
+];
+
+const loaders = {
+  ".json": (cosmiconfig as any).loadJson as LoaderEntry,
+  ".js": (cosmiconfig as any).loadJs as LoaderEntry,
+  ".ts": {
+    async: TypeScriptLoader
+  }
+};
+
+export const getConfig = async ({configFileName}: {configFileName?: string} = {}): Promise<Config | null> => {
+  const configPath = configFileName && parse(resolve(configFileName)).dir;
+  const explorer = cosmiconfig(MODULE_NAME, {
+    searchPlaces: configFileName ? [configFileName] : defaultFileNames,
+    loaders
+  });
+
+  let loadedConfig;
+  try {
+    loadedConfig = await explorer.search(configPath);
+  } catch (error) {
+    throw new Error(`A config file failed to load: ${error}`);
+  }
+
+  if (configPath && !loadedConfig) {
+    throw new Error(`A config file failed to load at ${configPath}. This is likely because this file is empty or malformed.`);
+  }
+
+
+  return loadedConfig && (loadedConfig.config as Config);
+}

--- a/packages/cli/src/utils/generateSchema.ts
+++ b/packages/cli/src/utils/generateSchema.ts
@@ -1,3 +1,4 @@
+import { Config } from './config';
 import { Codegen, fetchSchema } from '@gqless/schema'
 
 import { QueryFetcher } from 'gqless'
@@ -8,12 +9,8 @@ import * as path from 'path'
 
 export const generateSchema = async (
   fetchQuery: QueryFetcher,
-  options: {
+  options: Config & {
     outputDir: string
-    url?: string
-    typescript?: boolean
-    noComments?: boolean
-    noPrettier?: boolean
   }
 ) => {
   const schema = await fetchSchema(fetchQuery, {
@@ -22,6 +19,7 @@ export const generateSchema = async (
   const codegen = new Codegen(schema, {
     typescript: options.typescript,
     url: options.url,
+    headers: options.headers
   })
   const files = codegen.generate()
 

--- a/packages/cli/src/utils/generateSchema.ts
+++ b/packages/cli/src/utils/generateSchema.ts
@@ -1,4 +1,4 @@
-import { Config } from './config';
+import { Config } from './config'
 import { Codegen, fetchSchema } from '@gqless/schema'
 
 import { QueryFetcher } from 'gqless'
@@ -14,17 +14,16 @@ export const generateSchema = async (
   }
 ) => {
   const schema = await fetchSchema(fetchQuery, {
-    includeInfo: !options.noComments,
+    includeInfo: options.comments,
   })
   const codegen = new Codegen(schema, {
     typescript: options.typescript,
     url: options.url,
-    headers: options.headers
+    headers: options.headers,
   })
   const files = codegen.generate()
 
-  const prettierConfig =
-    !options.noPrettier && (await prettier.resolveConfig(options.outputDir))
+  const prettierConfig = await prettier.resolveConfig(options.outputDir)
 
   for (const file of files) {
     const filePath = path.join(options.outputDir, file.path)
@@ -32,12 +31,10 @@ export const generateSchema = async (
 
     if (!file.overwrite && fs.existsSync(filePath)) continue
 
-    const source = options.noPrettier
-      ? file.contents
-      : prettier.format(file.contents, {
-          ...prettierConfig,
-          parser: 'typescript',
-        })
+    const source = prettier.format(file.contents, {
+      ...prettierConfig,
+      parser: 'typescript',
+    })
 
     fs.writeFileSync(filePath, source)
   }

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from './config'
+export * from './generateSchema'

--- a/packages/schema/src/Codegen/Codegen.ts
+++ b/packages/schema/src/Codegen/Codegen.ts
@@ -5,6 +5,7 @@ import { File } from './File'
 interface CodegenOptions {
   url?: string
   typescript?: boolean
+  headers?: Record<string, string>
 }
 
 export class Codegen {

--- a/packages/schema/src/Codegen/files/client.ts
+++ b/packages/schema/src/Codegen/files/client.ts
@@ -19,7 +19,11 @@ export class ClientFile extends File {
         const response = await fetch(endpoint, {
           method: 'POST',
           headers: {
-            'Content-Type': 'application/json',
+            'Content-Type': 'application/json',${
+              this.codegen.options.headers ? Object.entries(this.codegen.options.headers).map(
+                ([key, value]) => `'${key}': '${value}'`
+              ).join('\n') : ''
+            }
           },
           body: JSON.stringify({
             query,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2365,13 +2365,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/cosmiconfig@^5.0.3":
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz#880644bb155d4038d3b752159684b777b0a159dd"
-  integrity sha512-HgTGG7X5y9pLl3pixeo2XtDEFD8rq2EuH+S4mK6teCnAwWMucQl6v1D43hI4Uw1VJh6nu59lxLkqXHRl4uwThA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1113,6 +1113,16 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
+"@endemolshinegroup/cosmiconfig-typescript-loader@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.1.tgz#484ee6f4e9209ffde5d3edbdacf03e0bc5ee0c67"
+  integrity sha512-bhUR9035PbgL6A/nfLayjoqKo4W7hCtzxqVxq2cgDB+Ndpsa3dGIr71/ymgY3vCTCQaufkFxAcEeoECyJ498CA==
+  dependencies:
+    lodash.get "^4"
+    make-error "^1"
+    ts-node "^8"
+    tslib "^1"
+
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -2355,6 +2365,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cosmiconfig@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@types/cosmiconfig/-/cosmiconfig-5.0.3.tgz#880644bb155d4038d3b752159684b777b0a159dd"
+  integrity sha512-HgTGG7X5y9pLl3pixeo2XtDEFD8rq2EuH+S4mK6teCnAwWMucQl6v1D43hI4Uw1VJh6nu59lxLkqXHRl4uwThA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2434,11 +2451,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@types/lodash@^4.14.144":
-  version "4.14.144"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.144.tgz#12e57fc99064bce45e5ab3c8bc4783feb75eab8e"
-  integrity sha512-ogI4g9W5qIQQUhXAclq6zhqgqNUr7UlFaqDHbch7WLSLeeM/7d3CRaw7GLajxvyFvhJqw4Rpcz5bhoaYtIx6Tg==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
@@ -9173,11 +9185,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -9228,7 +9235,7 @@ lodash.foreach@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.get@^4.4.2:
+lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -9430,7 +9437,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@1.x, make-error@^1, make-error@^1.1.1:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.5.tgz#efe4e81f6db28cadd605c70f29c831b58ef776c8"
   integrity sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==


### PR DESCRIPTION
Fixes #25 

Adds support for a config file. It can either be:

- `gqless` field in package.json
- `gqless.config.js` at the root level
- `gqless.config.ts` at the root level

It can basically contain all the options normally passed to the cli, so the cli call can just be `gqless generate`.

The cli also has support for some new flags:
- `-c` or `--config` and the path to a config file (if not in the previously mentioned)
- `--header` to pass headers used for the GraphQL calls. Can be multiple. Format: `--header "Authorization:Basic token"`
- `--usePost` uses POST to retrieve the schema instead of GET (needed for FaunaDB)

The headers are also included in the resulting client

TODOs:
- [ ] Add support for the client to pass the token in at runtime
- [ ] Update docs for the new options
- [ ] Update docs for the config file
- [ ] Update docs for any client changes for the token at runtime