### PR TITLE
Fix #84 do not add __typename to enums

### DIFF
--- a/.changeset/giant-shrimps-exist.md
+++ b/.changeset/giant-shrimps-exist.md
@@ -1,0 +1,5 @@
+---
+'gqless': patch
+---
+
+Fix bug adding \_\_typename field selection for the fields of enum type

--- a/gqless/src/QueryBuilder/buildSelection.ts
+++ b/gqless/src/QueryBuilder/buildSelection.ts
@@ -2,7 +2,7 @@ import { SelectionTree } from './SelectionTree'
 import { FieldSelection, Fragment } from '../Selection'
 import { Formatter } from './Formatter'
 import { buildArguments } from './buildArguments'
-import { ScalarNode, NodeContainer, ObjectNode } from '../Node'
+import { EnumNode, NodeContainer, ObjectNode, ScalarNode } from '../Node'
 import { Variables } from './buildVariable'
 
 export const buildSelections = (
@@ -15,7 +15,8 @@ export const buildSelections = (
       ? tree.selection.node.innerNode
       : tree.selection.node
 
-  if (innerNode instanceof ScalarNode) return ''
+  if (innerNode instanceof ScalarNode || innerNode instanceof EnumNode)
+    return ''
 
   const includeTypename =
     // When no selections or not on ObjectNode


### PR DESCRIPTION
The `EnumNode` node should be treated the same way as `ScalarNode` because it can't have nested fields (the `__typename` in this case). So, return early if node is instance of `EnumNode`.