### PR TITLE
Remove setTimeout in useForceUpdate

### DIFF
--- a/packages/react/src/common.ts
+++ b/packages/react/src/common.ts
@@ -57,7 +57,7 @@ export function useForceUpdate() {
       () => {
         if (wasCalled.current) return;
         wasCalled.current = true;
-        update();
+        Promise.resolve().then(update);
       },
       {
         wasCalled,

--- a/packages/react/src/common.ts
+++ b/packages/react/src/common.ts
@@ -57,7 +57,7 @@ export function useForceUpdate() {
       () => {
         if (wasCalled.current) return;
         wasCalled.current = true;
-        setTimeout(update);
+        update();
       },
       {
         wasCalled,


### PR DESCRIPTION
Fixes a common issue where gqless gets into a recursive loop of fetching, this was happening at weird times and across a variety of configurations. Tested this fix fixes it, but haven't tested what this setTimeout was meant to fix originally.